### PR TITLE
added pixel phone mask as alternative for showing screenshots to iphone

### DIFF
--- a/web/styles.tw.css
+++ b/web/styles.tw.css
@@ -21,6 +21,17 @@
         @apply bg-gray-700 hover:bg-gray-600 text-white;
     }
 
+    .pixel-mask {
+        position: relative;
+        width: 310px;
+        height: 680px;
+        margin: 0 auto;
+        overflow: hidden;
+        border-radius: 30px;
+        box-shadow: 0 0 0 12px #2b2b2b, 0 0 0 14px #1e1e1e, 0 0 0 22px #101010;
+        background-color: #000;
+    }
+
     .iphone-mask {
         position: relative;
         width: 300px;


### PR DESCRIPTION
As I was focusing on releasing to Android first for [Caza de Casa](https://cazadecasa.xyz/) I wanted to display the screenshot in an Android phone instead of an iPhone

I created something similar to the `iphone-mask` CSS class and wanted to add it to this template for others to use if they want

**How to use it**

``` dart
div(classes: 'pixel-mask', [
  img(
    src: AppConfig.heroImage2,
    alt: 'App Screenshot',
    classes: 'w-full h-auto'
  ),
]),
```

https://github.com/cazadecasa/caza_de_casa_landing_page_jaspr/blob/f567f8811352e27d1b899749ad02e76bd7718562/lib/pages/landing.dart#L31

**How it looks**

<img width="1728" alt="Screenshot 2024-09-23 at 09 44 11" src="https://github.com/user-attachments/assets/811dd37d-cf21-4eb2-b081-94773bf0ee5d">
